### PR TITLE
Add moderation setting logic and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ yarn-error.log*
 .Trashes
 ehthumbs.db
 Thumbs.db
+vendor/
+composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+  "require-dev": {
+    "phpunit/phpunit": "^9",
+    "brain/monkey": "^2"
+  },
+  "autoload": {
+    "classmap": ["includes/"]
+  }
+}

--- a/includes/class-igpr-form-handler.php
+++ b/includes/class-igpr-form-handler.php
@@ -67,12 +67,18 @@ class IGPR_Form_Handler {
             wp_send_json_error( array( 'message' => __( 'Please enter a valid email address.', 'instant-guest-post-request' ) ) );
         }
 
+        // Determine post status based on moderation setting
+        $moderation_enabled = true;
+        if ( isset( $settings['moderation_enabled'] ) ) {
+            $moderation_enabled = (bool) $settings['moderation_enabled'];
+        }
+
         // Prepare post data
         $post_data = array(
-            'post_title' => sanitize_text_field( wp_unslash( $_POST['post_title'] ) ),
+            'post_title'   => sanitize_text_field( wp_unslash( $_POST['post_title'] ) ),
             'post_content' => wp_kses_post( wp_unslash( $_POST['post_content'] ) ),
-            'post_status' => 'pending',
-            'post_type' => 'post',
+            'post_status'  => $moderation_enabled ? 'pending' : 'publish',
+            'post_type'    => 'post',
         );
 
         // Set category if specified in settings

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<phpunit bootstrap="tests/bootstrap.php">
+    <testsuites>
+        <testsuite name="Plugin Tests">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/FormHandlerTest.php
+++ b/tests/FormHandlerTest.php
@@ -1,0 +1,71 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+
+class FormHandlerTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+        $_FILES = array();
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    private function commonMocks($moderationEnabled) {
+        $_POST = array(
+            'nonce' => 'foo',
+            'post_title' => 'My Title',
+            'post_content' => 'My Content',
+            'author_name' => 'Tester',
+            'author_email' => 'test@example.com',
+        );
+
+        Functions\when('sanitize_text_field')->returnArg(1);
+        Functions\when('sanitize_email')->returnArg(1);
+        Functions\when('wp_unslash')->returnArg(1);
+        Functions\when('wp_verify_nonce')->justReturn(true);
+        Functions\when('wp_kses_post')->returnArg(1);
+        Functions\when('__')->returnArg(1);
+        Functions\when('is_email')->justReturn(true);
+        Functions\when('get_option')->justReturn([
+            'moderation_enabled' => $moderationEnabled,
+            'spam_protection' => false,
+            'submission_limit' => 0,
+        ]);
+        Functions\when('is_wp_error')->justReturn(false);
+        Functions\when('update_post_meta')->justReturn(null);
+        Functions\when('wp_send_json_success')->justReturn(null);
+    }
+
+    public function test_post_published_when_moderation_disabled() {
+        $this->commonMocks(false);
+        $captured = null;
+        Functions\when('wp_insert_post')->alias(function($data) use (&$captured) {
+            $captured = $data;
+            return 1;
+        });
+
+        $handler = new IGPR_Form_Handler();
+        $handler->handle_form_submission();
+
+        $this->assertSame('publish', $captured['post_status']);
+    }
+
+    public function test_post_pending_when_moderation_enabled() {
+        $this->commonMocks(true);
+        $captured = null;
+        Functions\when('wp_insert_post')->alias(function($data) use (&$captured) {
+            $captured = $data;
+            return 1;
+        });
+
+        $handler = new IGPR_Form_Handler();
+        $handler->handle_form_submission();
+
+        $this->assertSame('pending', $captured['post_status']);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+// Define minimal WordPress constants and load autoloader
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__);
+}
+if (!defined('DAY_IN_SECONDS')) {
+    define('DAY_IN_SECONDS', 86400);
+}
+require dirname(__DIR__) . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- respect `moderation_enabled` when creating posts
- ignore Composer artifacts
- add PHPUnit with Brain Monkey
- test published vs pending status

## Testing
- `vendor/bin/phpunit --colors=never`

------
https://chatgpt.com/codex/tasks/task_b_68400a989a4883248bcbd99f13e00d84