### PR TITLE
Add PHP and JS tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  testMatch: ['**/tests/e2e/**/*.js']
+};

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint:js": "wp-scripts lint-js",
     "lint:pkg-json": "wp-scripts lint-pkg-json",
     "packages-update": "wp-scripts packages-update",
-    "plugin-zip": "wp-scripts plugin-zip"
+    "plugin-zip": "wp-scripts plugin-zip",
+    "test:e2e": "npm run build && jest"
   },
   "author": "WordPress Developer",
   "license": "GPL-2.0-or-later",

--- a/tests/PostHandlerTest.php
+++ b/tests/PostHandlerTest.php
@@ -1,0 +1,34 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+
+class PostHandlerTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    public function test_generate_action_links() {
+        Functions\when('wp_create_nonce')->justReturn('abc');
+        Functions\when('admin_url')->justReturn('http://example.com/wp-admin/admin.php');
+        Functions\when('add_query_arg')->alias(function($args, $url) {
+            return $url . '?' . http_build_query($args);
+        });
+        Functions\when('get_preview_post_link')->alias(function($id){ return 'preview-' . $id; });
+        Functions\when('get_edit_post_link')->alias(function($id){ return 'edit-' . $id; });
+
+        $handler = new IGPR_Post_Handler();
+        $links = $handler->generate_action_links(10);
+
+        $this->assertSame('http://example.com/wp-admin/admin.php?igpr_action=approve&post_id=10&nonce=abc', $links['approve']);
+        $this->assertSame('http://example.com/wp-admin/admin.php?igpr_action=reject&post_id=10&nonce=abc', $links['reject']);
+        $this->assertSame('preview-10', $links['preview']);
+        $this->assertSame('edit-10', $links['admin']);
+    }
+}

--- a/tests/RateLimitTest.php
+++ b/tests/RateLimitTest.php
@@ -1,0 +1,66 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+
+class RateLimitTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+        Monkey\setUp();
+        Functions\when('sanitize_text_field')->returnArg(1);
+        Functions\when('wp_unslash')->returnArg(1);
+    }
+
+    protected function tearDown(): void {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    private function invokePrivate($object, string $method) {
+        $ref = new ReflectionMethod($object, $method);
+        $ref->setAccessible(true);
+        return $ref;
+    }
+
+    public function test_limit_not_exceeded() {
+        $_SERVER['REMOTE_ADDR'] = '1.2.3.4';
+        Functions\when('get_option')->justReturn(['submission_limit' => 3]);
+        Functions\when('get_transient')->justReturn(2);
+
+        $handler = new IGPR_Form_Handler();
+        $method = $this->invokePrivate($handler, 'is_submission_limit_exceeded');
+        $result = $method->invoke($handler);
+
+        $this->assertFalse($result);
+    }
+
+    public function test_limit_exceeded() {
+        $_SERVER['REMOTE_ADDR'] = '1.2.3.4';
+        Functions\when('get_option')->justReturn(['submission_limit' => 3]);
+        Functions\when('get_transient')->justReturn(3);
+
+        $handler = new IGPR_Form_Handler();
+        $method = $this->invokePrivate($handler, 'is_submission_limit_exceeded');
+        $this->assertTrue($method->invoke($handler));
+    }
+
+    public function test_record_submission_sets_transient() {
+        $_SERVER['REMOTE_ADDR'] = '1.2.3.4';
+        Functions\when('get_option')->justReturn(['submission_limit' => 3]);
+        Functions\when('get_transient')->justReturn(false);
+
+        $captured = [];
+        Functions\when('set_transient')->alias(function($key, $value, $expiration) use (&$captured) {
+            $captured = [$key, $value, $expiration];
+        });
+
+        $handler = new IGPR_Form_Handler();
+        $method = $this->invokePrivate($handler, 'record_submission');
+        $method->invoke($handler);
+
+        $expectedKey = 'igpr_submissions_' . md5('1.2.3.4');
+        $this->assertSame($expectedKey, $captured[0]);
+        $this->assertSame(1, $captured[1]);
+        $this->assertSame(DAY_IN_SECONDS, $captured[2]);
+    }
+}

--- a/tests/e2e/FrontendForm.test.js
+++ b/tests/e2e/FrontendForm.test.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+const { TextEncoder, TextDecoder } = require('util');
+
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+
+const { JSDOM } = require('jsdom');
+
+let dom;
+
+beforeAll(() => {
+  const html = fs.readFileSync(path.join(__dirname, 'form.html'), 'utf8');
+  dom = new JSDOM(html, { url: 'http://localhost' });
+
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.FormData = dom.window.FormData;
+  global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve({ success: true }) }));
+  global.igpr_params = { ajax_url: '/ajax', nonce: '123', i18n: { submit_error: 'error' } };
+  global.window.scrollTo = jest.fn();
+});
+
+afterAll(() => {
+  dom.window.close();
+});
+
+test('frontend script loads without errors', () => {
+  expect(() => {
+    require('../../build/frontend.js');
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded', { bubbles: true }));
+  }).not.toThrow();
+});

--- a/tests/e2e/form.html
+++ b/tests/e2e/form.html
@@ -1,0 +1,16 @@
+<html>
+<body>
+<div class="igpr-form-messages hidden">
+  <div class="igpr-success hidden"></div>
+  <div class="igpr-error hidden"></div>
+</div>
+<form id="igpr-guest-post-form">
+  <input type="text" name="post_title" />
+  <textarea name="post_content"></textarea>
+  <input type="text" name="author_name" />
+  <input type="email" name="author_email" />
+  <button id="igpr-submit-button">Submit</button>
+  <span id="igpr-spinner" class="hidden"></span>
+</form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add PHPUnit tests for rate limiting logic
- add test for post action links
- add Jest-based E2E test that loads the frontend bundle
- include jest configuration and npm script

## Testing
- `vendor/bin/phpunit`
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_b_6840218a9950832481cf7cbf118edc82