### PR TITLE
Fix email approval links

### DIFF
--- a/tests/PostHandlerTest.php
+++ b/tests/PostHandlerTest.php
@@ -15,6 +15,7 @@ class PostHandlerTest extends TestCase {
     }
 
     public function test_generate_action_links() {
+        Functions\when('get_post_meta')->justReturn('');
         Functions\when('wp_generate_password')->justReturn('tok');
         Functions\when('wp_hash_password')->justReturn('hashed');
         Functions\when('update_post_meta')->justReturn(null);

--- a/tests/PostHandlerTest.php
+++ b/tests/PostHandlerTest.php
@@ -15,7 +15,9 @@ class PostHandlerTest extends TestCase {
     }
 
     public function test_generate_action_links() {
-        Functions\when('wp_create_nonce')->justReturn('abc');
+        Functions\when('wp_generate_password')->justReturn('tok');
+        Functions\when('wp_hash_password')->justReturn('hashed');
+        Functions\when('update_post_meta')->justReturn(null);
         Functions\when('admin_url')->justReturn('http://example.com/wp-admin/admin.php');
         Functions\when('add_query_arg')->alias(function($args, $url) {
             return $url . '?' . http_build_query($args);
@@ -26,8 +28,8 @@ class PostHandlerTest extends TestCase {
         $handler = new IGPR_Post_Handler();
         $links = $handler->generate_action_links(10);
 
-        $this->assertSame('http://example.com/wp-admin/admin.php?igpr_action=approve&post_id=10&nonce=abc', $links['approve']);
-        $this->assertSame('http://example.com/wp-admin/admin.php?igpr_action=reject&post_id=10&nonce=abc', $links['reject']);
+        $this->assertSame('http://example.com/wp-admin/admin.php?igpr_action=approve&post_id=10&token=tok', $links['approve']);
+        $this->assertSame('http://example.com/wp-admin/admin.php?igpr_action=reject&post_id=10&token=tok', $links['reject']);
         $this->assertSame('preview-10', $links['preview']);
         $this->assertSame('edit-10', $links['admin']);
     }


### PR DESCRIPTION
## Summary
- generate approval links with a token instead of user-specific nonces
- verify and consume the token when handling approval
- adjust unit tests for the new behaviour

## Testing
- `composer install`
- `./vendor/bin/phpunit --configuration phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_b_68402d9ce5648324bf8eaa5d9eaa7150